### PR TITLE
#2 Add: Pieceクラスの修正

### DIFF
--- a/src/main/java/com/github/com/shii_park/shogi2vs2/model/domain/Board.java
+++ b/src/main/java/com/github/com/shii_park/shogi2vs2/model/domain/Board.java
@@ -1,6 +1,6 @@
-package com.github.com.shii_park.shogi2vs2.model.domain;
+// package com.github.com.shii_park.shogi2vs2.model.domain;
 
-public class Board {
-    private final Map<Position,Piece>board;
+// public class Board {
+//     private final Map<Position,Piece>board;
     
-}
+// }

--- a/src/main/java/com/github/com/shii_park/shogi2vs2/model/domain/Piece.java
+++ b/src/main/java/com/github/com/shii_park/shogi2vs2/model/domain/Piece.java
@@ -10,7 +10,7 @@ public class Piece {
     private Team team;
     private Position position;
     private boolean promoted; //成りの有無
-    private final boolean promotable;
+    private final boolean promotable; //成れるかどうか
 
     //ownerIdについては要検討
     public Piece(short id,PieceType type,Team team,Position position,boolean promotable){

--- a/src/main/java/com/github/com/shii_park/shogi2vs2/model/domain/Piece.java
+++ b/src/main/java/com/github/com/shii_park/shogi2vs2/model/domain/Piece.java
@@ -5,7 +5,7 @@ import com.github.com.shii_park.shogi2vs2.model.enums.Team;
 
 
 public class Piece {
-    private final Short id;
+    private final int id;
     private final PieceType type;
     private Team team;
     private Position position;
@@ -13,7 +13,7 @@ public class Piece {
     private final boolean promotable; //成れるかどうか
 
     //ownerIdについては要検討
-    public Piece(short id,PieceType type,Team team,Position position,boolean promotable){
+    public Piece(int id,PieceType type,Team team,Position position,boolean promotable){
         this.id=id;
         this.type=type;
         this.team=team;
@@ -22,7 +22,7 @@ public class Piece {
         this.promotable=promotable;
     }
 
-    public short getId(){return id;}
+    public int getId(){return id;}
     public Team getTeam(){return team;}
     public PieceType getType(){return type;}
     public Position getPosition(){return position;}

--- a/src/main/java/com/github/com/shii_park/shogi2vs2/model/domain/Piece.java
+++ b/src/main/java/com/github/com/shii_park/shogi2vs2/model/domain/Piece.java
@@ -5,14 +5,14 @@ import com.github.com.shii_park.shogi2vs2.model.enums.Team;
 
 
 public class Piece {
-    private final String id;
+    private final Short id;
     private final PieceType type;
-    private final Team team;
+    private Team team;
     private Position position;
     private boolean promoted; //成りの有無
 
     //ownerIdについては要検討
-    public Piece(String id,PieceType type,Team team,Position position){
+    public Piece(short id,PieceType type,Team team,Position position){
         this.id=id;
         this.type=type;
         this.team=team;
@@ -20,7 +20,7 @@ public class Piece {
         this.promoted=false;
     }
 
-    public String getId(){return id;}
+    public short getId(){return id;}
     public Team getTeam(){return team;}
     public PieceType getType(){return type;}
     public Position getPosition(){return position;}

--- a/src/main/java/com/github/com/shii_park/shogi2vs2/model/domain/Piece.java
+++ b/src/main/java/com/github/com/shii_park/shogi2vs2/model/domain/Piece.java
@@ -10,14 +10,16 @@ public class Piece {
     private Team team;
     private Position position;
     private boolean promoted; //成りの有無
+    private final boolean promotable;
 
     //ownerIdについては要検討
-    public Piece(short id,PieceType type,Team team,Position position){
+    public Piece(short id,PieceType type,Team team,Position position,boolean promotable){
         this.id=id;
         this.type=type;
         this.team=team;
         this.position=position;
         this.promoted=false;
+        this.promotable=promotable;
     }
 
     public short getId(){return id;}
@@ -27,6 +29,7 @@ public class Piece {
     public void setPosition(Position p){this.position=p;}
     public boolean isPromoted(){return promoted;}
     public void setPromoted(boolean p){this.promoted=p;}
+    public boolean isPromotable(){return promotable;}
 
     //デバック用
     @Override


### PR DESCRIPTION
# やったこと
- idの型をStringからintに変更
- teamのfinal修飾子を削除
- promotable(成りの可否)を追加
# なぜそうしたのか
### idの型の変更
- 設計を見直した結果、文字列が不要になったため
- intのほうが軽量かつ扱いやすいため
### teamのfinal修飾子削除
-  駒を捕獲した際など、teamが変わる場面があるため
### promotable追加
- 金将、王将は成りが不可能なため
- 金将、王将のpromoted(現在成っているかどうか)を常にtrueにする案もあったが、promotedの意味が壊れるので不採用
# その他
### コンパイル通りません
- アプリのメインのファイルをまだ実装していないので