### PR TITLE
Add: Dockerfileの初期構成を作成

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# 2vs2将棋 バックエンドサーバ  
+## 構成  
+- Java 21  
+- Spring Boot 3.5.8  
+- Gradle 8

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,24 @@
+# --- 1. ビルドステージ (Builder) ---
+FROM gradle:8-jdk21-alpine AS builder
+
+WORKDIR /app
+
+COPY build.gradle settings.gradle ./
+
+RUN gradle dependencies --no-daemon
+
+COPY src ./src
+
+RUN gradle bootJar --no-daemon -x test
+
+# --- 2. 実行ステージ (Runner) ---
+FROM eclipse-temurin:21-jre-alpine
+
+WORKDIR /app
+
+
+COPY --from=builder /app/build/libs/*.jar app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
## やったこと
   - アプリケーションをコンテナ化するための dockerfile を作成しました。
   - マルチステージビルドを採用し、ビルド環境（Gradle + JDK 21）と実行環境（JRE 21）を分離しました。

 ## なぜそうしたのか
   - 開発・本番環境での動作の一貫性を保ち、デプロイを容易にするため。
   - 実行イメージのサイズを軽量化するため。

 ## その他
   - ビルド時間を短縮するため、依存関係の解決とソースコードのビルドを段階的に行っています。
   - docker build 時にテスト実行はスキップする設定 (-x test) にしています。