### PR TITLE
Chore: build.gradleの構成を修正しました

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,17 +19,13 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	//implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
-	runtimeOnly 'org.postgresql:postgresql'
-	//テスト用に追加したコード
-	//Redis用のパッケージを追加したらここは削除してください
-	testImplementation 'com.h2database:h2'
-	//テスト用に追加したコードここまで 
+	//runtimeOnly 'org.postgresql:postgresql'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'


### PR DESCRIPTION
# 概要  
build.gradleの構成を変更しました 

# 変更点  
- JPAのパッケージをコメントアウト
- PosgreSQLのパッケージをコメントアウト
- テスト用に追加したh2databaseを削除

# 変更理由  
- データベースを使用しないのに依存関係に含めると、dockerのビルド時にエラーが発生するため
- (今後の仕様変更の可能性はあるが)現在のところデータベースは使用しないため
- ただしエラーが出たときのために現在はコメントアウトにとどめています

# テスト
- [x] コンパイルok
- [x] 単体テストok  

# その他  