### PR TITLE
Add: 手駒から駒を置く処理を追加

### DIFF
--- a/src/main/java/com/github/com/shii_park/shogi2vs2/model/domain/CapturedPieces.java
+++ b/src/main/java/com/github/com/shii_park/shogi2vs2/model/domain/CapturedPieces.java
@@ -46,6 +46,31 @@ public class CapturedPieces {
         return winnerTeam;
     }
 
+    /**
+     * 手駒から駒を取り出す。駒のidは考慮しない
+     * 
+     * @param team  駒を取り出したいチーム
+     * @param piece 取り出す駒
+     * @return 取り出した駒を返す。手駒に存在しなかった場合は{@code null}
+     */
+    public Piece getCapturedPiece(Team team, Piece piece) {
+        List<Piece> pieces = capturedPieces.get(team);
+        if (pieces == null) {
+            return null;
+        }
+
+        synchronized (pieces) {
+            for (int i = 0; i < pieces.size(); i++) {
+                Piece captured = pieces.get(i);
+                if (captured.getType() == piece.getType()) {
+                    pieces.remove(i);
+                    return captured;
+                }
+            }
+        }
+        return null;
+    }
+
     // TODO: winnerTeamを決める処理を別途追加
     /**
      * 駒を捕獲する

--- a/src/main/java/com/github/com/shii_park/shogi2vs2/model/domain/Game.java
+++ b/src/main/java/com/github/com/shii_park/shogi2vs2/model/domain/Game.java
@@ -55,7 +55,7 @@ public class Game {
         if (!board.isTop(m1.piece()) && !board.isTop(m2.piece())) {
             return;
         }
-
+        // TODO: resign処理の切り分け
         if (m1.player().isResign() || m2.player().isResign()) {
             handleResign(m1.player().getTeam());
         }
@@ -110,6 +110,23 @@ public class Game {
         }
         turnManager.nextTurn();
 
+    }
+
+    /**
+     * プレイヤーの手駒を盤面に配置する
+     * 
+     * @param drop プレイヤーの手駒から盤面に打つ操作
+     */
+    public void applyDrop(PlayerDropPiece drop) {
+        if (board.getTopPiece(drop.position()) != null) {
+            return;
+        }
+        Piece piece = capturedPieces.getCapturedPiece(drop.player().getTeam(), drop.piece());
+        if (piece == null) {
+            return;
+        }
+        board.stackPiece(drop.position(), piece);
+        return;
     }
 
     /**

--- a/src/main/java/com/github/com/shii_park/shogi2vs2/model/domain/PlayerDropPiece.java
+++ b/src/main/java/com/github/com/shii_park/shogi2vs2/model/domain/PlayerDropPiece.java
@@ -1,0 +1,13 @@
+package com.github.com.shii_park.shogi2vs2.model.domain;
+
+/**
+ * PlayerDropPieceクラスは手駒から盤面に駒を打つ操作を管理し、それらのゲッターを提供します
+ * 
+ * @param player   行動するプレイヤー
+ * @param piece    盤面に置く駒
+ * @param position 盤面の置く位置
+ * 
+ * @author Suiren91
+ */
+public record PlayerDropPiece(Player player, Piece piece, Position position) {
+}

--- a/src/test/java/com/github/com/shii_park/shogi2vs2/model/domain/CapturedPiecesTest.java
+++ b/src/test/java/com/github/com/shii_park/shogi2vs2/model/domain/CapturedPiecesTest.java
@@ -147,4 +147,73 @@ class CapturedPiecesTest {
         assertEquals(1, capturedPieces.getCapturedPieces(Team.FIRST).size());
         assertEquals(1, capturedPieces.getCapturedPieces(Team.SECOND).size());
     }
+
+    /**
+     * 手駒から駒を取り出すテスト
+     * 処理: 捕獲した駒を手駒から取り出せることを確認
+     */
+    @Test
+    void testGetCapturedPiece() {
+        // FIRSTチームがpawn2を捕獲
+        capturedPieces.capturedPiece(Team.FIRST, pawn2);
+        // FIRSTチームの捕獲リストに1つの駒が含まれることを確認
+        assertEquals(1, capturedPieces.getCapturedPieces(Team.FIRST).size());
+        // pawn2と同じタイプの駒を取り出す
+        Piece retrieved = capturedPieces.getCapturedPiece(Team.FIRST, pawn2);
+        // 取り出した駒がpawn2であることを確認
+        assertEquals(pawn2, retrieved);
+        // 捕獲リストから駒が削除されたことを確認
+        assertEquals(0, capturedPieces.getCapturedPieces(Team.FIRST).size());
+    }
+
+    /**
+     * 手駒に存在しない駒を取り出すテスト
+     * 処理: 手駒に存在しない駒を取り出そうとするとnullが返ることを確認
+     */
+    @Test
+    void testGetCapturedPieceNotFound() {
+        // 何も捕獲していない状態でpawn1を取り出そうとする
+        Piece retrieved = capturedPieces.getCapturedPiece(Team.FIRST, pawn1);
+        // nullが返ることを確認
+        assertNull(retrieved);
+    }
+
+    /**
+     * 手駒から同じタイプの駒を取り出すテスト
+     * 処理: 同じタイプの駒が複数ある場合、最初に見つかった駒を取り出すことを確認
+     */
+    @Test
+    void testGetCapturedPieceSameType() {
+        // FIRSTチームがpawn2を捕獲
+        capturedPieces.capturedPiece(Team.FIRST, pawn2);
+        // 新しい歩兵を生成して捕獲
+        Piece pawn3 = new Piece(4, PieceType.PAWN, Team.SECOND, true);
+        capturedPieces.capturedPiece(Team.FIRST, pawn3);
+        // FIRSTチームの捕獲リストに2つの駒が含まれることを確認
+        assertEquals(2, capturedPieces.getCapturedPieces(Team.FIRST).size());
+        // 歩兵タイプの駒を取り出す
+        Piece retrieved = capturedPieces.getCapturedPiece(Team.FIRST, new Piece(99, PieceType.PAWN, Team.FIRST, false));
+        // 取り出した駒がnullでないことを確認
+        assertNotNull(retrieved);
+        // 取り出した駒のタイプが歩兵であることを確認
+        assertEquals(PieceType.PAWN, retrieved.getType());
+        // 捕獲リストから1つ減ったことを確認
+        assertEquals(1, capturedPieces.getCapturedPieces(Team.FIRST).size());
+    }
+
+    /**
+     * 異なるタイプの駒を取り出すテスト
+     * 処理: 手駒に存在しないタイプの駒を取り出そうとするとnullが返ることを確認
+     */
+    @Test
+    void testGetCapturedPieceDifferentType() {
+        // FIRSTチームが歩兵を捕獲
+        capturedPieces.capturedPiece(Team.FIRST, pawn2);
+        // 歩兵ではなく王将タイプの駒を取り出そうとする
+        Piece retrieved = capturedPieces.getCapturedPiece(Team.FIRST, king);
+        // nullが返ることを確認
+        assertNull(retrieved);
+        // 手駒は削除されていないことを確認
+        assertEquals(1, capturedPieces.getCapturedPieces(Team.FIRST).size());
+    }
 }

--- a/src/test/java/com/github/com/shii_park/shogi2vs2/model/domain/GameTest.java
+++ b/src/test/java/com/github/com/shii_park/shogi2vs2/model/domain/GameTest.java
@@ -223,4 +223,110 @@ class GameTest {
         // 勝者が決定したことを確認
         assertNotNull(game.getWinnerTeam());
     }
+
+    /**
+     * 手駒から盤面に駒を打つテスト（正常系）
+     * 処理: 手駒から駒を取り出して空いているマスに配置できることを確認
+     */
+    @Test
+    void testApplyDropSuccess() {
+        // FIRSTチームがSECONDチームの歩兵を捕獲
+        Piece capturedPawn = new Piece(10, PieceType.PAWN, Team.SECOND, false);
+        board.getCapturedPieces().capturedPiece(Team.FIRST, capturedPawn);
+        // 手駒に1つの駒が含まれることを確認
+        assertEquals(1, board.getCapturedPieces().getCapturedPieces(Team.FIRST).size());
+
+        // 空いている位置を指定
+        Position dropPosition = new Position(3, 3);
+        // 空いていることを確認
+        assertNull(board.getTopPiece(dropPosition));
+
+        // player1が手駒から(3, 3)に駒を打つ
+        PlayerDropPiece drop = new PlayerDropPiece(player1, capturedPawn, dropPosition);
+        game.applyDrop(drop);
+
+        // (3, 3)に駒が配置されたことを確認
+        assertNotNull(board.getTopPiece(dropPosition));
+        // 配置された駒がcapturedPawnであることを確認
+        assertEquals(capturedPawn, board.getTopPiece(dropPosition));
+        // 手駒から駒が削除されたことを確認
+        assertEquals(0, board.getCapturedPieces().getCapturedPieces(Team.FIRST).size());
+    }
+
+    /**
+     * 駒がある位置に手駒を打とうとするテスト
+     * 処理: すでに駒がある位置には打てないことを確認
+     */
+    @Test
+    void testApplyDropToOccupiedPosition() {
+        // FIRSTチームがSECONDチームの歩兵を捕獲
+        Piece capturedPawn = new Piece(10, PieceType.PAWN, Team.SECOND, false);
+        board.getCapturedPieces().capturedPiece(Team.FIRST, capturedPawn);
+
+        // すでに駒がある位置を指定
+        Position occupiedPosition = new Position(5, 5);
+        // piece1が(5, 5)にいることを確認
+        assertEquals(piece1, board.getTopPiece(occupiedPosition));
+
+        // player1が(5, 5)に駒を打とうとする
+        PlayerDropPiece drop = new PlayerDropPiece(player1, capturedPawn, occupiedPosition);
+        game.applyDrop(drop);
+
+        // piece1がまだ(5, 5)にいることを確認
+        assertEquals(piece1, board.getTopPiece(occupiedPosition));
+        // 手駒が削除されていないことを確認
+        assertEquals(1, board.getCapturedPieces().getCapturedPieces(Team.FIRST).size());
+    }
+
+    /**
+     * 手駒に存在しない駒を打とうとするテスト
+     * 処理: 手駒に存在しない駒は打てないことを確認
+     */
+    @Test
+    void testApplyDropNonExistentPiece() {
+        // 手駒が空であることを確認
+        assertEquals(0, board.getCapturedPieces().getCapturedPieces(Team.FIRST).size());
+
+        // 存在しない駒を打とうとする
+        Piece nonExistentPiece = new Piece(99, PieceType.PAWN, Team.FIRST, false);
+        Position dropPosition = new Position(3, 3);
+        PlayerDropPiece drop = new PlayerDropPiece(player1, nonExistentPiece, dropPosition);
+        game.applyDrop(drop);
+
+        // (3, 3)に駒が配置されていないことを確認
+        assertNull(board.getTopPiece(dropPosition));
+    }
+
+    /**
+     * 複数の手駒を順番に打つテスト
+     * 処理: 複数の手駒を順番に盤面に配置できることを確認
+     */
+    @Test
+    void testApplyDropMultiplePieces() {
+        // FIRSTチームが2つの駒を捕獲
+        Piece capturedPawn1 = new Piece(10, PieceType.PAWN, Team.SECOND, false);
+        Piece capturedPawn2 = new Piece(11, PieceType.PAWN, Team.SECOND, false);
+        board.getCapturedPieces().capturedPiece(Team.FIRST, capturedPawn1);
+        board.getCapturedPieces().capturedPiece(Team.FIRST, capturedPawn2);
+        // 手駒に2つの駒が含まれることを確認
+        assertEquals(2, board.getCapturedPieces().getCapturedPieces(Team.FIRST).size());
+
+        // 1つ目の駒を打つ
+        Position dropPosition1 = new Position(3, 3);
+        PlayerDropPiece drop1 = new PlayerDropPiece(player1, capturedPawn1, dropPosition1);
+        game.applyDrop(drop1);
+        // (3, 3)に駒が配置されたことを確認
+        assertNotNull(board.getTopPiece(dropPosition1));
+        // 手駒が1つ減ったことを確認
+        assertEquals(1, board.getCapturedPieces().getCapturedPieces(Team.FIRST).size());
+
+        // 2つ目の駒を打つ
+        Position dropPosition2 = new Position(4, 4);
+        PlayerDropPiece drop2 = new PlayerDropPiece(player1, capturedPawn2, dropPosition2);
+        game.applyDrop(drop2);
+        // (4, 4)に駒が配置されたことを確認
+        assertNotNull(board.getTopPiece(dropPosition2));
+        // 手駒が空になったことを確認
+        assertEquals(0, board.getCapturedPieces().getCapturedPieces(Team.FIRST).size());
+    }
 }


### PR DESCRIPTION
# 概要  
手駒を取り出す処理、手駒から駒を盤面に置く処理を追加しました

# 変更点  
- 手駒を置く操作のドメインオブジェクト`PlayerDropPiece`の作成
- CapturedPiecesクラスに手駒を取り出すための`getCapturedPieces`メソッドを追加
- Gameクラスに手駒から盤面に打つ`applyDrop`メソッドを追加
- テストコード追加

# 変更理由  
- PlayerMoveと別のドメインオブジェクトが必要であったため
- GameクラスとCapturedPiecesクラスの責務を分割するため
- (手駒に関する処理はCapturedPieces,それを盤面に打つ処理はGameクラス)

# テスト
- [x] コンパイルok
- [x] 単体テストok  

# その他  
- 現状は**1ターンで2人が手駒から同じ場所に手駒から駒を置くことができません**
- この問題を解決するために
  -   applyDropを、変更を予約するメソッドにする
  - 予約した変更を確定するメソッドを作成する

  を行う予定ですが、これは別のプルリクエストを出します。