### PR TITLE
Feature/position normalize

### DIFF
--- a/src/main/java/com/github/com/shii_park/shogi2vs2/service/BoardCoordinateService.java
+++ b/src/main/java/com/github/com/shii_park/shogi2vs2/service/BoardCoordinateService.java
@@ -1,0 +1,33 @@
+package com.github.com.shii_park.shogi2vs2.service;
+
+import org.springframework.stereotype.Service;
+
+import com.github.com.shii_park.shogi2vs2.model.domain.Position;
+
+@Service
+public class BoardCoordinateService {
+    // 将棋盤の最大インデックス (9マスなので 0 〜 8)
+    private static final int BOARD_SIZE_INDEX = 8;
+
+    /**
+     * チームIDに応じて座標を正規化（反転）する
+     * * @param pos 元の座標
+     * @param teamId チームID ("FIRST" or "SECOND")
+     * @return 正規化された座標
+     */
+    public Position normalize(Position pos, String teamId) {
+        // nullチェック
+        if (pos == null) return null;
+
+        // Team2 (SECOND) の場合のみ、盤面を180度回転させる
+        if ("SECOND".equals(teamId)) {
+            // 例: (0, 0) -> (8, 8)
+            // 例: (8, 8) -> (0, 0)
+            // 例: (4, 4) -> (4, 4)
+            return new Position(BOARD_SIZE_INDEX - pos.x(), BOARD_SIZE_INDEX - pos.y());
+        }
+
+        // Team1 (FIRST) なら何もしない
+        return pos;
+    }
+}


### PR DESCRIPTION
概要
TEAM2（後手番）からの入力、およびTEAM2への出力を適切に処理するため、座標と方向を反転（正規化）させるロジックを実装しました。 主に BoardCoordinateService の新規作成と、Direction Enumへのロジック追加を行っています。

変更点
BoardCoordinateService クラスを作成

normalize(Position, teamId) メソッドを実装（TEAM2の場合のみ 8 - x で座標を反転）

Direction Enum に normalize(teamId) メソッドを追加

チームIDを渡すだけで、適切な方向（TEAM2なら反転した方向）を返すように変更

外部から直接 reverse() を呼ばせないよう private に変更

GameRoomService および NotificationService の修正

手動で計算していた反転処理を削除し、上記サービス・メソッドを利用するように変更

変更理由
サーバー内部では常に「TEAM1（先手）視点」で盤面を管理するため、TEAM2からの入力を統一座標系に変換する必要があるため

反転ロジックを各Serviceに散らばらせず、BoardCoordinateService や Direction 内部に隠蔽することで、実装ミス（反転忘れ・二重反転）を防ぐため

GameRoomService のコードの可読性を向上させるため

テスト
[ ] コンパイルok

[ ] 単体テストok（TEAM2の座標 (0,0) が (8,8) に変換されること）

[ ] 動作確認ok（簡易クライアントでTEAM2の駒が意図した方向に動くこと）

その他
Direction の reverse メソッドを normalize 経由で呼び出す形に変更したため、既存のコードでコンパイルエラーが出ていないか確認をお願いします。