### PR TITLE
Add: 駒の移動可能な方向をチェックする処理を実装

### DIFF
--- a/src/main/java/com/github/com/shii_park/shogi2vs2/model/domain/Game.java
+++ b/src/main/java/com/github/com/shii_park/shogi2vs2/model/domain/Game.java
@@ -59,6 +59,12 @@ public class Game {
         if (!board.isTop(move.piece())) {
             return;
         }
+        
+        // 移動可能かチェック
+        if (!isMovable(move.direction(), move.piece())) {
+            return;
+        }
+        
         // 飛車、角行など、複数マス移動する駒は繰り返し実行する
         for (Direction dir : move.direction()) {
             MoveResult res = board.moveOneStep(move.piece(), dir);
@@ -158,5 +164,50 @@ public class Game {
      */
     public Board getBoard() {
         return board;
+    }
+
+    /**
+     * 駒が指定された方向リストに移動可能かチェックする
+     * 
+     * @param directions 移動方向のリスト
+     * @param piece      移動させたい駒
+     * @return {@code true}:全ての移動が可能
+     */
+    private boolean isMovable(List<Direction> directions, Piece piece) {
+        if (directions == null || directions.isEmpty()) {
+            return false;
+        }
+        
+        // 1. 各方向が移動可能な方向かチェック
+        for (Direction dir : directions) {
+            if (!piece.canMoveToDirection(dir)) {
+                return false;
+            }
+        }
+        
+        // 2. 連続移動のチェック
+        if (directions.size() > 1) {
+            // 連続移動可能な駒かチェック
+            if (!piece.canMoveMultipleSteps()) {
+                return false;
+            }
+            
+            // 3. 各方向が連続移動可能な方向かチェック
+            for (Direction dir : directions) {
+                if (!piece.canMoveMultipleStepsInDirection(dir)) {
+                    return false;
+                }
+            }
+            
+            // 同じ方向への連続移動かチェック（飛車・角・香は同じ方向にのみ連続移動可）
+            Direction firstDir = directions.get(0);
+            for (Direction dir : directions) {
+                if (dir != firstDir) {
+                    return false;
+                }
+            }
+        }
+        
+        return true;
     }
 }

--- a/src/main/java/com/github/com/shii_park/shogi2vs2/model/domain/Piece.java
+++ b/src/main/java/com/github/com/shii_park/shogi2vs2/model/domain/Piece.java
@@ -45,8 +45,9 @@ public class Piece {
     }
 
     /**
-     * 指定方向に移動可能か
+     * 指定方向に移動可能か判定する
      * 
+     * @param direction 移動方向
      * @return {@code true}:移動可能
      */
     public boolean canMoveToDirection(Direction direction) {

--- a/src/main/java/com/github/com/shii_park/shogi2vs2/model/domain/Piece.java
+++ b/src/main/java/com/github/com/shii_park/shogi2vs2/model/domain/Piece.java
@@ -1,5 +1,8 @@
 package com.github.com.shii_park.shogi2vs2.model.domain;
 
+import java.util.List;
+
+import com.github.com.shii_park.shogi2vs2.model.enums.Direction;
 import com.github.com.shii_park.shogi2vs2.model.enums.PieceType;
 import com.github.com.shii_park.shogi2vs2.model.enums.Team;
 
@@ -27,6 +30,48 @@ public class Piece {
         this.team = team;
         this.isPromoted = false;
         this.isPromotable = promotable;
+    }
+
+    /**
+     * この駒が移動可能な方向のリストを返す
+     * チームに応じて方向を調整する
+     * 
+     * @return 移動可能な方向のリスト
+     */
+    public List<Direction> getMovableDirections() {
+        return type.getMovableDirections(isPromoted).stream()
+                .map(dir -> dir.forTeam(team))
+                .toList();
+    }
+
+    /**
+     * 指定方向に移動可能か
+     * 
+     * @return {@code true}:移動可能
+     */
+    public boolean canMoveToDirection(Direction direction) {
+        return getMovableDirections().contains(direction);
+    }
+
+    /**
+     * 連続移動可能か
+     * 
+     * @return {@code true}:連続移動可能
+     */
+    public boolean canMoveMultipleSteps() {
+        return type.canMoveMultipleSteps(isPromoted);
+    }
+
+    /**
+     * 指定方向に連続移動可能か
+     * （飛車は縦横のみ、角行は斜めのみ連続移動可）
+     * 
+     * @return {@code true}:指定方向に連続移動可能
+     */
+    public boolean canMoveMultipleStepsInDirection(Direction direction) {
+        // チームに応じて方向を逆変換
+        Direction normalizedDir = direction.forTeam(team);
+        return type.canMoveMultipleStepsInDirection(normalizedDir, isPromoted);
     }
 
     public int getId() {

--- a/src/main/java/com/github/com/shii_park/shogi2vs2/model/domain/Piece.java
+++ b/src/main/java/com/github/com/shii_park/shogi2vs2/model/domain/Piece.java
@@ -55,7 +55,7 @@ public class Piece {
     }
 
     /**
-     * 連続移動可能か
+     * 連続移動可能か判定する
      * 
      * @return {@code true}:連続移動可能
      */

--- a/src/main/java/com/github/com/shii_park/shogi2vs2/model/domain/Piece.java
+++ b/src/main/java/com/github/com/shii_park/shogi2vs2/model/domain/Piece.java
@@ -66,6 +66,7 @@ public class Piece {
      * 指定方向に連続移動可能か
      * （飛車は縦横のみ、角行は斜めのみ連続移動可）
      * 
+     * @param direction 連続移動したい方向
      * @return {@code true}:指定方向に連続移動可能
      */
     public boolean canMoveMultipleStepsInDirection(Direction direction) {

--- a/src/main/java/com/github/com/shii_park/shogi2vs2/model/enums/PieceType.java
+++ b/src/main/java/com/github/com/shii_park/shogi2vs2/model/enums/PieceType.java
@@ -114,7 +114,7 @@ public enum PieceType {
     /**
      * 竜王
      * 
-     * @return 縦横+斜め1マスs
+     * @return 縦横+斜め1マス
      */
     private static List<Direction> getPromotedRookMovement() {
         List<Direction> directions = new ArrayList<>(getRookMovement());

--- a/src/main/java/com/github/com/shii_park/shogi2vs2/model/enums/PieceType.java
+++ b/src/main/java/com/github/com/shii_park/shogi2vs2/model/enums/PieceType.java
@@ -1,16 +1,46 @@
 package com.github.com.shii_park.shogi2vs2.model.enums;
 
+import java.util.List;
+
+/**
+ * PAWN:歩兵
+ * LANCE:香車
+ * KNIGHT:桂馬
+ * SILVER:銀将
+ * GOLD:金将
+ * BISHOP:角行
+ * ROOK:飛車
+ * KING:王将
+ */
 public enum PieceType {
     PAWN, LANCE, KNIGHT, SILVER, GOLD, BISHOP, ROOK, KING;
-}
 
-/*
-PAWN:歩兵
-LANCE:香車
-KNIGHT:桂馬
-SILVER:銀将
-GOLD:金将
-BISHOP:角行
-ROOK:飛車
-KING:王将
-*/
+    /**
+     * この駒の移動可能な方向のリストを返す
+     * 
+     * @param isPromoted 成っているかどうか
+     * @return 移動可能な方向リスト
+     */
+    public List<Direction> getMovableDirections(boolean isPromoted) {
+        if (isPromoted && this != GOLD && this != KING) {
+            return GOLD.getMovableDirections(false);
+        }
+        return switch (this) {
+            case PAWN -> List.of(Direction.UP);
+            case LANCE -> List.of(Direction.UP);
+            case KNIGHT -> List.of(Direction.KNIGHT_LEFT, Direction.KNIGHT_RIGHT);
+            case SILVER ->
+                List.of(Direction.UP, Direction.UP_LEFT, Direction.UP_RIGHT, Direction.DOWN_LEFT, Direction.DOWN_RIGHT);
+            case GOLD -> List.of(Direction.UP, Direction.UP_LEFT, Direction.UP_RIGHT, Direction.LEFT, Direction.RIGHT,
+                    Direction.DOWN);
+            case BISHOP -> List.of(Direction.UP_LEFT, Direction.UP_RIGHT, Direction.DOWN_LEFT, Direction.DOWN_RIGHT);
+            case ROOK -> List.of(Direction.UP, Direction.DOWN, Direction.LEFT, Direction.RIGHT);
+            case KING -> List.of(Direction.UP, Direction.DOWN, Direction.LEFT, Direction.RIGHT, Direction.UP_LEFT,
+                    Direction.UP_RIGHT, Direction.DOWN_LEFT, Direction.DOWN_RIGHT);
+        };
+    }
+
+    public boolean canMoveMultipleSteps() {
+        return this == ROOK || this == BISHOP || this == LANCE;
+    }
+}

--- a/src/main/java/com/github/com/shii_park/shogi2vs2/model/enums/PieceType.java
+++ b/src/main/java/com/github/com/shii_park/shogi2vs2/model/enums/PieceType.java
@@ -1,5 +1,6 @@
 package com.github.com.shii_park.shogi2vs2.model.enums;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -22,25 +23,102 @@ public enum PieceType {
      * @return 移動可能な方向リスト
      */
     public List<Direction> getMovableDirections(boolean isPromoted) {
-        if (isPromoted && this != GOLD && this != KING) {
-            return GOLD.getMovableDirections(false);
-        }
         return switch (this) {
-            case PAWN -> List.of(Direction.UP);
-            case LANCE -> List.of(Direction.UP);
-            case KNIGHT -> List.of(Direction.KNIGHT_LEFT, Direction.KNIGHT_RIGHT);
-            case SILVER ->
-                List.of(Direction.UP, Direction.UP_LEFT, Direction.UP_RIGHT, Direction.DOWN_LEFT, Direction.DOWN_RIGHT);
-            case GOLD -> List.of(Direction.UP, Direction.UP_LEFT, Direction.UP_RIGHT, Direction.LEFT, Direction.RIGHT,
-                    Direction.DOWN);
-            case BISHOP -> List.of(Direction.UP_LEFT, Direction.UP_RIGHT, Direction.DOWN_LEFT, Direction.DOWN_RIGHT);
-            case ROOK -> List.of(Direction.UP, Direction.DOWN, Direction.LEFT, Direction.RIGHT);
-            case KING -> List.of(Direction.UP, Direction.DOWN, Direction.LEFT, Direction.RIGHT, Direction.UP_LEFT,
-                    Direction.UP_RIGHT, Direction.DOWN_LEFT, Direction.DOWN_RIGHT);
+            case PAWN -> isPromoted ? getGoldMovement() : List.of(Direction.UP);
+            case LANCE -> isPromoted ? getGoldMovement() : List.of(Direction.UP);
+            case KNIGHT -> isPromoted ? getGoldMovement() : List.of(Direction.KNIGHT_LEFT, Direction.KNIGHT_RIGHT);
+            case SILVER -> isPromoted ? getGoldMovement()
+                    : List.of(Direction.UP, Direction.UP_LEFT, Direction.UP_RIGHT,
+                            Direction.DOWN_LEFT, Direction.DOWN_RIGHT);
+            case GOLD -> getGoldMovement();
+            case BISHOP -> isPromoted ? getPromotedBishopMovement() : getBishopMovement();
+            case ROOK -> isPromoted ? getPromotedRookMovement() : getRookMovement();
+            case KING -> List.of(Direction.UP, Direction.DOWN, Direction.LEFT, Direction.RIGHT,
+                    Direction.UP_LEFT, Direction.UP_RIGHT,
+                    Direction.DOWN_LEFT, Direction.DOWN_RIGHT);
         };
     }
 
-    public boolean canMoveMultipleSteps() {
-        return this == ROOK || this == BISHOP || this == LANCE;
+    /**
+     * 駒が連続移動可能かを判定する
+     * 
+     * @param isPromoted 成っているかどうか
+     * @return {@code true}:連続移動可能
+     */
+    public boolean canMoveMultipleSteps(boolean isPromoted) {
+        return switch (this) {
+            case LANCE -> !isPromoted;
+            case BISHOP, ROOK -> true;
+            default -> false;
+        };
+    }
+
+    /**
+     * 駒が指定した方向に連続移動可能か判定する
+     * 
+     * @param direction  方向
+     * @param isPromoted 成っているか
+     * @return {@code true}:連続移動可能
+     */
+    public boolean canMoveMultipleStepsInDirection(Direction direction, boolean isPromoted) {
+        return switch (this) {
+            case LANCE -> !isPromoted && direction == Direction.UP;
+            case BISHOP -> getBishopMovement().contains(direction);
+            case ROOK -> getRookMovement().contains(direction);
+            default -> false;
+        };
+    }
+
+    // ヘルパーメソッド(Private)
+
+    /**
+     * 金将
+     * 
+     * @return 上3方向、横、下
+     */
+    private static List<Direction> getGoldMovement() {
+        return List.of(Direction.UP, Direction.UP_LEFT, Direction.UP_RIGHT,
+                Direction.LEFT, Direction.RIGHT, Direction.DOWN);
+    }
+
+    /**
+     * 角行
+     * 
+     * @return 斜め
+     */
+    private static List<Direction> getBishopMovement() {
+        return List.of(Direction.UP_LEFT, Direction.UP_RIGHT,
+                Direction.DOWN_LEFT, Direction.DOWN_RIGHT);
+    }
+
+    /**
+     * 飛車
+     * 
+     * @return 縦横
+     */
+    private static List<Direction> getRookMovement() {
+        return List.of(Direction.UP, Direction.DOWN, Direction.LEFT, Direction.RIGHT);
+    }
+
+    /**
+     * 龍馬
+     * 
+     * @return 斜め+縦横1マス
+     */
+    private static List<Direction> getPromotedBishopMovement() {
+        List<Direction> directions = new ArrayList<>(getBishopMovement());
+        directions.addAll(getRookMovement()); // 縦横も追加
+        return directions;
+    }
+
+    /**
+     * 竜王
+     * 
+     * @return 縦横+斜め1マスs
+     */
+    private static List<Direction> getPromotedRookMovement() {
+        List<Direction> directions = new ArrayList<>(getRookMovement());
+        directions.addAll(getBishopMovement()); // 斜めも追加
+        return directions;
     }
 }

--- a/src/test/java/com/github/com/shii_park/shogi2vs2/model/domain/GameIsMovableTest.java
+++ b/src/test/java/com/github/com/shii_park/shogi2vs2/model/domain/GameIsMovableTest.java
@@ -1,0 +1,316 @@
+package com.github.com.shii_park.shogi2vs2.model.domain;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.github.com.shii_park.shogi2vs2.model.enums.Direction;
+import com.github.com.shii_park.shogi2vs2.model.enums.PieceType;
+import com.github.com.shii_park.shogi2vs2.model.enums.Team;
+
+/**
+ * Game.isMovable()メソッドのテスト
+ * 駒の移動可能性バリデーションを検証
+ */
+class GameIsMovableTest {
+
+    private Game game;
+    private Board board;
+    private Player player1;
+    private Player player2;
+    private Piece pawn;
+    private Piece rook;
+    private Piece bishop;
+    private Piece knight;
+
+    @BeforeEach
+    void setUp() {
+        board = BoardFactory.createBoard();
+        
+        player1 = new Player("p1", Team.FIRST);
+        player2 = new Player("p2", Team.SECOND);
+        
+        // テスト用の駒を取得
+        pawn = board.getTopPiece(new Position(1, 3));     // FIRSTの歩兵
+        rook = board.getTopPiece(new Position(2, 2));     // FIRSTの飛車
+        bishop = board.getTopPiece(new Position(8, 2));   // FIRSTの角行
+        knight = board.getTopPiece(new Position(2, 1));   // FIRSTの桂馬
+        
+        game = new Game("game1", List.of(player1, player2), board, Team.FIRST);
+    }
+
+    /**
+     * 歩兵の正常な移動（前に1マス）
+     */
+    @Test
+    void testPawnValidMove() {
+        PlayerMove move = new PlayerMove(player1, pawn, List.of(Direction.UP), false);
+        
+        Position initialPos = board.find(pawn);
+        game.applyMove(move);
+        game.handleTurnEnd();
+        
+        // 移動が成功したことを確認
+        Position newPos = board.find(pawn);
+        assertEquals(initialPos.y() + 1, newPos.y());
+    }
+
+    /**
+     * 歩兵の不正な移動（横に移動しようとする）
+     */
+    @Test
+    void testPawnInvalidMove() {
+        PlayerMove move = new PlayerMove(player1, pawn, List.of(Direction.LEFT), false);
+        
+        Position initialPos = board.find(pawn);
+        game.applyMove(move);
+        game.handleTurnEnd();
+        
+        // 移動が拒否されたことを確認（位置が変わらない）
+        Position currentPos = board.find(pawn);
+        assertEquals(initialPos, currentPos);
+    }
+
+    /**
+     * 歩兵の連続移動は不可
+     */
+    @Test
+    void testPawnCannotMoveMultipleSteps() {
+        PlayerMove move = new PlayerMove(player1, pawn, List.of(Direction.UP, Direction.UP), false);
+        
+        Position initialPos = board.find(pawn);
+        game.applyMove(move);
+        game.handleTurnEnd();
+        
+        // 移動が拒否されたことを確認
+        Position currentPos = board.find(pawn);
+        assertEquals(initialPos, currentPos);
+    }
+
+    /**
+     * 飛車の縦方向への連続移動
+     */
+    @Test
+    void testRookValidMultipleSteps() {
+        // 飛車の前の歩兵を取り除く
+        board.captureAll(new Position(2, 3), Team.SECOND);
+        
+        PlayerMove move = new PlayerMove(player1, rook, 
+                                         List.of(Direction.UP, Direction.UP, Direction.UP), false);
+        
+        Position initialPos = board.find(rook);
+        game.applyMove(move);
+        game.handleTurnEnd();
+        
+        // 3マス上に移動したことを確認
+        Position newPos = board.find(rook);
+        assertEquals(initialPos.y() + 3, newPos.y());
+    }
+
+    /**
+     * 飛車の斜め移動は不可
+     */
+    @Test
+    void testRookCannotMoveDiagonally() {
+        PlayerMove move = new PlayerMove(player1, rook, List.of(Direction.UP_LEFT), false);
+        
+        Position initialPos = board.find(rook);
+        game.applyMove(move);
+        game.handleTurnEnd();
+        
+        // 移動が拒否されたことを確認
+        Position currentPos = board.find(rook);
+        assertEquals(initialPos, currentPos);
+    }
+
+    /**
+     * 角行の斜め方向への連続移動
+     */
+    @Test
+    void testBishopValidMultipleSteps() {
+        // 角行の前の歩兵を取り除く
+        board.captureAll(new Position(7, 3), Team.SECOND);
+        
+        PlayerMove move = new PlayerMove(player1, bishop, 
+                                         List.of(Direction.UP_LEFT, Direction.UP_LEFT), false);
+        
+        Position initialPos = board.find(bishop);
+        game.applyMove(move);
+        game.handleTurnEnd();
+        
+        // 斜め左上に2マス移動したことを確認
+        Position newPos = board.find(bishop);
+        assertEquals(initialPos.x() - 2, newPos.x());
+        assertEquals(initialPos.y() + 2, newPos.y());
+    }
+
+    /**
+     * 角行の縦方向への移動は不可
+     */
+    @Test
+    void testBishopCannotMoveVertically() {
+        PlayerMove move = new PlayerMove(player1, bishop, List.of(Direction.UP), false);
+        
+        Position initialPos = board.find(bishop);
+        game.applyMove(move);
+        game.handleTurnEnd();
+        
+        // 移動が拒否されたことを確認
+        Position currentPos = board.find(bishop);
+        assertEquals(initialPos, currentPos);
+    }
+
+    /**
+     * 桂馬の正常な移動
+     */
+    @Test
+    void testKnightValidMove() {
+        PlayerMove move = new PlayerMove(player1, knight, List.of(Direction.KNIGHT_LEFT), false);
+        
+        Position initialPos = board.find(knight);
+        game.applyMove(move);
+        game.handleTurnEnd();
+        
+        // 移動が成功したことを確認
+        Position newPos = board.find(knight);
+        assertNotEquals(initialPos, newPos);
+    }
+
+    /**
+     * 桂馬の連続移動は不可
+     */
+    @Test
+    void testKnightCannotMoveMultipleSteps() {
+        PlayerMove move = new PlayerMove(player1, knight, 
+                                         List.of(Direction.KNIGHT_LEFT, Direction.KNIGHT_LEFT), false);
+        
+        Position initialPos = board.find(knight);
+        game.applyMove(move);
+        game.handleTurnEnd();
+        
+        // 移動が拒否されたことを確認
+        Position currentPos = board.find(knight);
+        assertEquals(initialPos, currentPos);
+    }
+
+    /**
+     * 空の方向リストは移動不可
+     */
+    @Test
+    void testEmptyDirectionList() {
+        PlayerMove move = new PlayerMove(player1, pawn, List.of(), false);
+        
+        Position initialPos = board.find(pawn);
+        game.applyMove(move);
+        game.handleTurnEnd();
+        
+        // 移動が拒否されたことを確認
+        Position currentPos = board.find(pawn);
+        assertEquals(initialPos, currentPos);
+    }
+
+    /**
+     * 飛車が異なる方向への連続移動は不可（曲がれない）
+     */
+    @Test
+    void testRookCannotChangeDirection() {
+        // 飛車の前の歩兵を取り除く
+        board.captureAll(new Position(2, 3), Team.SECOND);
+        
+        // 上に移動してから右に移動しようとする
+        PlayerMove move = new PlayerMove(player1, rook, 
+                                         List.of(Direction.UP, Direction.RIGHT), false);
+        
+        Position initialPos = board.find(rook);
+        game.applyMove(move);
+        game.handleTurnEnd();
+        
+        // 移動が拒否されたことを確認
+        Position currentPos = board.find(rook);
+        assertEquals(initialPos, currentPos);
+    }
+
+    /**
+     * 成り飛車（龍王）の斜め1マス移動は可能
+     */
+    @Test
+    void testPromotedRookCanMoveDiagonallyOneStep() {
+        // 飛車を成らせる
+        rook.setPromoted(true);
+        
+        PlayerMove move = new PlayerMove(player1, rook, List.of(Direction.UP_LEFT), false);
+        
+        Position initialPos = board.find(rook);
+        game.applyMove(move);
+        game.handleTurnEnd();
+        
+        // 移動が成功したことを確認
+        Position newPos = board.find(rook);
+        assertEquals(initialPos.x() - 1, newPos.x());
+        assertEquals(initialPos.y() + 1, newPos.y());
+    }
+
+    /**
+     * 成り飛車（龍王）の斜め連続移動は不可
+     */
+    @Test
+    void testPromotedRookCannotMoveDiagonallyMultipleSteps() {
+        // 飛車を成らせる
+        rook.setPromoted(true);
+        
+        // 斜めに2マス移動しようとする
+        PlayerMove move = new PlayerMove(player1, rook, 
+                                         List.of(Direction.UP_LEFT, Direction.UP_LEFT), false);
+        
+        Position initialPos = board.find(rook);
+        game.applyMove(move);
+        game.handleTurnEnd();
+        
+        // 移動が拒否されたことを確認
+        Position currentPos = board.find(rook);
+        assertEquals(initialPos, currentPos);
+    }
+
+    /**
+     * 成り角（龍馬）の縦方向1マス移動は可能
+     */
+    @Test
+    void testPromotedBishopCanMoveVerticallyOneStep() {
+        // 角行を成らせる
+        bishop.setPromoted(true);
+        
+        PlayerMove move = new PlayerMove(player1, bishop, List.of(Direction.UP), false);
+        
+        Position initialPos = board.find(bishop);
+        game.applyMove(move);
+        game.handleTurnEnd();
+        
+        // 移動が成功したことを確認
+        Position newPos = board.find(bishop);
+        assertEquals(initialPos.y() + 1, newPos.y());
+    }
+
+    /**
+     * 成り角（龍馬）の縦方向連続移動は不可
+     */
+    @Test
+    void testPromotedBishopCannotMoveVerticallyMultipleSteps() {
+        // 角行を成らせる
+        bishop.setPromoted(true);
+        
+        // 縦に2マス移動しようとする
+        PlayerMove move = new PlayerMove(player1, bishop, 
+                                         List.of(Direction.UP, Direction.UP), false);
+        
+        Position initialPos = board.find(bishop);
+        game.applyMove(move);
+        game.handleTurnEnd();
+        
+        // 移動が拒否されたことを確認
+        Position currentPos = board.find(bishop);
+        assertEquals(initialPos, currentPos);
+    }
+}

--- a/src/test/java/com/github/com/shii_park/shogi2vs2/model/domain/GameTest.java
+++ b/src/test/java/com/github/com/shii_park/shogi2vs2/model/domain/GameTest.java
@@ -183,22 +183,33 @@ class GameTest {
 
     /**
      * 複数マス移動テスト
-     * 処理: 1つの移動コマンドで複数の方向を指定して、駒が連続して移動することを確認
+     * 処理: 飛車が連続して移動することを確認
      */
     @Test
     void testMultipleMoves() {
-        // piece1を初期位置に配置
-        board.movePiece(piece1, new Position(5, 5));
+        // 飛車を使用（連続移動可能な駒）
+        Piece rook = new Piece(1, PieceType.ROOK, Team.FIRST, true);
+        Position rookPos = new Position(5, 5);
+        
+        // 盤面に飛車を配置
+        Map<Piece, Position> initialPieces = new HashMap<>();
+        initialPieces.put(rook, rookPos);
+        initialPieces.put(piece2, new Position(6, 6));
+        Board newBoard = new Board(initialPieces);
+        
+        game = new Game("game1", List.of(player1, player2), newBoard, Team.FIRST);
+        
         // 上に2マス移動する指示
-        PlayerMove move1 = new PlayerMove(player1, piece1, List.of(Direction.UP, Direction.UP), false);
+        PlayerMove move1 = new PlayerMove(player1, rook, List.of(Direction.UP, Direction.UP), false);
         PlayerMove move2 = new PlayerMove(player2, piece2, List.of(Direction.DOWN), false);
 
         // 移動を適用
         game.applyMove(move1);
         game.applyMove(move2);
         game.handleTurnEnd();
-        // piece1が(5, 7)に移動したことを確認（2マス上）
-        assertEquals(new Position(5, 7), board.find(piece1));
+        
+        // rookが(5, 7)に移動したことを確認（2マス上）
+        assertEquals(new Position(5, 7), newBoard.find(rook));
     }
 
     /**

--- a/src/test/java/com/github/com/shii_park/shogi2vs2/model/enums/PieceTypeTest.java
+++ b/src/test/java/com/github/com/shii_park/shogi2vs2/model/enums/PieceTypeTest.java
@@ -1,0 +1,428 @@
+package com.github.com.shii_park.shogi2vs2.model.enums;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * PieceTypeクラスのテスト
+ * 各駒の移動可能方向、連続移動可否、成り駒の動きを検証
+ */
+class PieceTypeTest {
+
+    /**
+     * 歩兵の移動可能方向のテスト（成っていない）
+     */
+    @Test
+    void testPawnMovableDirections() {
+        List<Direction> directions = PieceType.PAWN.getMovableDirections(false);
+        
+        assertEquals(1, directions.size());
+        assertTrue(directions.contains(Direction.UP));
+    }
+
+    /**
+     * 歩兵の成り駒（金将の動き）のテスト
+     */
+    @Test
+    void testPromotedPawnMovableDirections() {
+        List<Direction> directions = PieceType.PAWN.getMovableDirections(true);
+        
+        assertEquals(6, directions.size());
+        assertTrue(directions.contains(Direction.UP));
+        assertTrue(directions.contains(Direction.UP_LEFT));
+        assertTrue(directions.contains(Direction.UP_RIGHT));
+        assertTrue(directions.contains(Direction.LEFT));
+        assertTrue(directions.contains(Direction.RIGHT));
+        assertTrue(directions.contains(Direction.DOWN));
+        // 斜め後ろには移動できない
+        assertFalse(directions.contains(Direction.DOWN_LEFT));
+        assertFalse(directions.contains(Direction.DOWN_RIGHT));
+    }
+
+    /**
+     * 香車の移動可能方向のテスト（成っていない）
+     */
+    @Test
+    void testLanceMovableDirections() {
+        List<Direction> directions = PieceType.LANCE.getMovableDirections(false);
+        
+        assertEquals(1, directions.size());
+        assertTrue(directions.contains(Direction.UP));
+    }
+
+    /**
+     * 香車の成り駒（金将の動き）のテスト
+     */
+    @Test
+    void testPromotedLanceMovableDirections() {
+        List<Direction> directions = PieceType.LANCE.getMovableDirections(true);
+        
+        assertEquals(6, directions.size());
+        assertTrue(directions.contains(Direction.UP));
+        assertTrue(directions.contains(Direction.UP_LEFT));
+        assertTrue(directions.contains(Direction.UP_RIGHT));
+        assertTrue(directions.contains(Direction.LEFT));
+        assertTrue(directions.contains(Direction.RIGHT));
+        assertTrue(directions.contains(Direction.DOWN));
+    }
+
+    /**
+     * 桂馬の移動可能方向のテスト（成っていない）
+     */
+    @Test
+    void testKnightMovableDirections() {
+        List<Direction> directions = PieceType.KNIGHT.getMovableDirections(false);
+        
+        assertEquals(2, directions.size());
+        assertTrue(directions.contains(Direction.KNIGHT_LEFT));
+        assertTrue(directions.contains(Direction.KNIGHT_RIGHT));
+    }
+
+    /**
+     * 桂馬の成り駒（金将の動き）のテスト
+     */
+    @Test
+    void testPromotedKnightMovableDirections() {
+        List<Direction> directions = PieceType.KNIGHT.getMovableDirections(true);
+        
+        assertEquals(6, directions.size());
+        assertTrue(directions.contains(Direction.UP));
+        assertTrue(directions.contains(Direction.UP_LEFT));
+        assertTrue(directions.contains(Direction.UP_RIGHT));
+        assertTrue(directions.contains(Direction.LEFT));
+        assertTrue(directions.contains(Direction.RIGHT));
+        assertTrue(directions.contains(Direction.DOWN));
+    }
+
+    /**
+     * 銀将の移動可能方向のテスト（成っていない）
+     */
+    @Test
+    void testSilverMovableDirections() {
+        List<Direction> directions = PieceType.SILVER.getMovableDirections(false);
+        
+        assertEquals(5, directions.size());
+        assertTrue(directions.contains(Direction.UP));
+        assertTrue(directions.contains(Direction.UP_LEFT));
+        assertTrue(directions.contains(Direction.UP_RIGHT));
+        assertTrue(directions.contains(Direction.DOWN_LEFT));
+        assertTrue(directions.contains(Direction.DOWN_RIGHT));
+        // 横と真後ろには移動できない
+        assertFalse(directions.contains(Direction.LEFT));
+        assertFalse(directions.contains(Direction.RIGHT));
+        assertFalse(directions.contains(Direction.DOWN));
+    }
+
+    /**
+     * 銀将の成り駒（金将の動き）のテスト
+     */
+    @Test
+    void testPromotedSilverMovableDirections() {
+        List<Direction> directions = PieceType.SILVER.getMovableDirections(true);
+        
+        assertEquals(6, directions.size());
+        assertTrue(directions.contains(Direction.UP));
+        assertTrue(directions.contains(Direction.UP_LEFT));
+        assertTrue(directions.contains(Direction.UP_RIGHT));
+        assertTrue(directions.contains(Direction.LEFT));
+        assertTrue(directions.contains(Direction.RIGHT));
+        assertTrue(directions.contains(Direction.DOWN));
+    }
+
+    /**
+     * 金将の移動可能方向のテスト
+     */
+    @Test
+    void testGoldMovableDirections() {
+        List<Direction> directions = PieceType.GOLD.getMovableDirections(false);
+        
+        assertEquals(6, directions.size());
+        assertTrue(directions.contains(Direction.UP));
+        assertTrue(directions.contains(Direction.UP_LEFT));
+        assertTrue(directions.contains(Direction.UP_RIGHT));
+        assertTrue(directions.contains(Direction.LEFT));
+        assertTrue(directions.contains(Direction.RIGHT));
+        assertTrue(directions.contains(Direction.DOWN));
+        // 斜め後ろには移動できない
+        assertFalse(directions.contains(Direction.DOWN_LEFT));
+        assertFalse(directions.contains(Direction.DOWN_RIGHT));
+    }
+
+    /**
+     * 金将は成れない（成っても変わらない）
+     */
+    @Test
+    void testGoldCannotBePromoted() {
+        List<Direction> unpromoted = PieceType.GOLD.getMovableDirections(false);
+        List<Direction> promoted = PieceType.GOLD.getMovableDirections(true);
+        
+        assertEquals(unpromoted, promoted);
+    }
+
+    /**
+     * 角行の移動可能方向のテスト（成っていない）
+     */
+    @Test
+    void testBishopMovableDirections() {
+        List<Direction> directions = PieceType.BISHOP.getMovableDirections(false);
+        
+        assertEquals(4, directions.size());
+        assertTrue(directions.contains(Direction.UP_LEFT));
+        assertTrue(directions.contains(Direction.UP_RIGHT));
+        assertTrue(directions.contains(Direction.DOWN_LEFT));
+        assertTrue(directions.contains(Direction.DOWN_RIGHT));
+        // 縦横には移動できない
+        assertFalse(directions.contains(Direction.UP));
+        assertFalse(directions.contains(Direction.DOWN));
+        assertFalse(directions.contains(Direction.LEFT));
+        assertFalse(directions.contains(Direction.RIGHT));
+    }
+
+    /**
+     * 角行の成り駒（龍馬）: 斜め + 縦横
+     */
+    @Test
+    void testPromotedBishopMovableDirections() {
+        List<Direction> directions = PieceType.BISHOP.getMovableDirections(true);
+        
+        assertEquals(8, directions.size());
+        // 斜め（元々の動き）
+        assertTrue(directions.contains(Direction.UP_LEFT));
+        assertTrue(directions.contains(Direction.UP_RIGHT));
+        assertTrue(directions.contains(Direction.DOWN_LEFT));
+        assertTrue(directions.contains(Direction.DOWN_RIGHT));
+        // 縦横（追加された動き）
+        assertTrue(directions.contains(Direction.UP));
+        assertTrue(directions.contains(Direction.DOWN));
+        assertTrue(directions.contains(Direction.LEFT));
+        assertTrue(directions.contains(Direction.RIGHT));
+    }
+
+    /**
+     * 飛車の移動可能方向のテスト（成っていない）
+     */
+    @Test
+    void testRookMovableDirections() {
+        List<Direction> directions = PieceType.ROOK.getMovableDirections(false);
+        
+        assertEquals(4, directions.size());
+        assertTrue(directions.contains(Direction.UP));
+        assertTrue(directions.contains(Direction.DOWN));
+        assertTrue(directions.contains(Direction.LEFT));
+        assertTrue(directions.contains(Direction.RIGHT));
+        // 斜めには移動できない
+        assertFalse(directions.contains(Direction.UP_LEFT));
+        assertFalse(directions.contains(Direction.UP_RIGHT));
+        assertFalse(directions.contains(Direction.DOWN_LEFT));
+        assertFalse(directions.contains(Direction.DOWN_RIGHT));
+    }
+
+    /**
+     * 飛車の成り駒（龍王）: 縦横 + 斜め
+     */
+    @Test
+    void testPromotedRookMovableDirections() {
+        List<Direction> directions = PieceType.ROOK.getMovableDirections(true);
+        
+        assertEquals(8, directions.size());
+        // 縦横（元々の動き）
+        assertTrue(directions.contains(Direction.UP));
+        assertTrue(directions.contains(Direction.DOWN));
+        assertTrue(directions.contains(Direction.LEFT));
+        assertTrue(directions.contains(Direction.RIGHT));
+        // 斜め（追加された動き）
+        assertTrue(directions.contains(Direction.UP_LEFT));
+        assertTrue(directions.contains(Direction.UP_RIGHT));
+        assertTrue(directions.contains(Direction.DOWN_LEFT));
+        assertTrue(directions.contains(Direction.DOWN_RIGHT));
+    }
+
+    /**
+     * 王将の移動可能方向のテスト
+     */
+    @Test
+    void testKingMovableDirections() {
+        List<Direction> directions = PieceType.KING.getMovableDirections(false);
+        
+        assertEquals(8, directions.size());
+        assertTrue(directions.contains(Direction.UP));
+        assertTrue(directions.contains(Direction.DOWN));
+        assertTrue(directions.contains(Direction.LEFT));
+        assertTrue(directions.contains(Direction.RIGHT));
+        assertTrue(directions.contains(Direction.UP_LEFT));
+        assertTrue(directions.contains(Direction.UP_RIGHT));
+        assertTrue(directions.contains(Direction.DOWN_LEFT));
+        assertTrue(directions.contains(Direction.DOWN_RIGHT));
+    }
+
+    /**
+     * 王将は成れない（成っても変わらない）
+     */
+    @Test
+    void testKingCannotBePromoted() {
+        List<Direction> unpromoted = PieceType.KING.getMovableDirections(false);
+        List<Direction> promoted = PieceType.KING.getMovableDirections(true);
+        
+        assertEquals(unpromoted, promoted);
+    }
+
+    /**
+     * 連続移動可能な駒のテスト（香車・成っていない）
+     */
+    @Test
+    void testLanceCanMoveMultipleSteps() {
+        assertTrue(PieceType.LANCE.canMoveMultipleSteps(false));
+        assertFalse(PieceType.LANCE.canMoveMultipleSteps(true)); // 成香は連続移動不可
+    }
+
+    /**
+     * 連続移動可能な駒のテスト（角行）
+     */
+    @Test
+    void testBishopCanMoveMultipleSteps() {
+        assertTrue(PieceType.BISHOP.canMoveMultipleSteps(false));
+        assertTrue(PieceType.BISHOP.canMoveMultipleSteps(true)); // 成っても連続移動可
+    }
+
+    /**
+     * 連続移動可能な駒のテスト（飛車）
+     */
+    @Test
+    void testRookCanMoveMultipleSteps() {
+        assertTrue(PieceType.ROOK.canMoveMultipleSteps(false));
+        assertTrue(PieceType.ROOK.canMoveMultipleSteps(true)); // 成っても連続移動可
+    }
+
+    /**
+     * 連続移動不可能な駒のテスト
+     */
+    @Test
+    void testOtherPiecesCannotMoveMultipleSteps() {
+        assertFalse(PieceType.PAWN.canMoveMultipleSteps(false));
+        assertFalse(PieceType.KNIGHT.canMoveMultipleSteps(false));
+        assertFalse(PieceType.SILVER.canMoveMultipleSteps(false));
+        assertFalse(PieceType.GOLD.canMoveMultipleSteps(false));
+        assertFalse(PieceType.KING.canMoveMultipleSteps(false));
+    }
+
+    /**
+     * 香車の方向別連続移動テスト
+     */
+    @Test
+    void testLanceCanMoveMultipleStepsInDirection() {
+        // 成っていない香車はUP方向のみ連続移動可能
+        assertTrue(PieceType.LANCE.canMoveMultipleStepsInDirection(Direction.UP, false));
+        assertFalse(PieceType.LANCE.canMoveMultipleStepsInDirection(Direction.DOWN, false));
+        assertFalse(PieceType.LANCE.canMoveMultipleStepsInDirection(Direction.LEFT, false));
+        assertFalse(PieceType.LANCE.canMoveMultipleStepsInDirection(Direction.RIGHT, false));
+        
+        // 成香は連続移動不可
+        assertFalse(PieceType.LANCE.canMoveMultipleStepsInDirection(Direction.UP, true));
+    }
+
+    /**
+     * 角行の方向別連続移動テスト
+     */
+    @Test
+    void testBishopCanMoveMultipleStepsInDirection() {
+        // 斜め方向のみ連続移動可能
+        assertTrue(PieceType.BISHOP.canMoveMultipleStepsInDirection(Direction.UP_LEFT, false));
+        assertTrue(PieceType.BISHOP.canMoveMultipleStepsInDirection(Direction.UP_RIGHT, false));
+        assertTrue(PieceType.BISHOP.canMoveMultipleStepsInDirection(Direction.DOWN_LEFT, false));
+        assertTrue(PieceType.BISHOP.canMoveMultipleStepsInDirection(Direction.DOWN_RIGHT, false));
+        
+        // 縦横方向は連続移動不可
+        assertFalse(PieceType.BISHOP.canMoveMultipleStepsInDirection(Direction.UP, false));
+        assertFalse(PieceType.BISHOP.canMoveMultipleStepsInDirection(Direction.DOWN, false));
+        assertFalse(PieceType.BISHOP.canMoveMultipleStepsInDirection(Direction.LEFT, false));
+        assertFalse(PieceType.BISHOP.canMoveMultipleStepsInDirection(Direction.RIGHT, false));
+    }
+
+    /**
+     * 成角（龍馬）の方向別連続移動テスト
+     * 斜めは連続移動可、縦横は1マスのみ
+     */
+    @Test
+    void testPromotedBishopCanMoveMultipleStepsInDirection() {
+        // 斜め方向は連続移動可能
+        assertTrue(PieceType.BISHOP.canMoveMultipleStepsInDirection(Direction.UP_LEFT, true));
+        assertTrue(PieceType.BISHOP.canMoveMultipleStepsInDirection(Direction.UP_RIGHT, true));
+        assertTrue(PieceType.BISHOP.canMoveMultipleStepsInDirection(Direction.DOWN_LEFT, true));
+        assertTrue(PieceType.BISHOP.canMoveMultipleStepsInDirection(Direction.DOWN_RIGHT, true));
+        
+        // 縦横方向は連続移動不可（1マスのみ）
+        assertFalse(PieceType.BISHOP.canMoveMultipleStepsInDirection(Direction.UP, true));
+        assertFalse(PieceType.BISHOP.canMoveMultipleStepsInDirection(Direction.DOWN, true));
+        assertFalse(PieceType.BISHOP.canMoveMultipleStepsInDirection(Direction.LEFT, true));
+        assertFalse(PieceType.BISHOP.canMoveMultipleStepsInDirection(Direction.RIGHT, true));
+    }
+
+    /**
+     * 飛車の方向別連続移動テスト
+     */
+    @Test
+    void testRookCanMoveMultipleStepsInDirection() {
+        // 縦横方向のみ連続移動可能
+        assertTrue(PieceType.ROOK.canMoveMultipleStepsInDirection(Direction.UP, false));
+        assertTrue(PieceType.ROOK.canMoveMultipleStepsInDirection(Direction.DOWN, false));
+        assertTrue(PieceType.ROOK.canMoveMultipleStepsInDirection(Direction.LEFT, false));
+        assertTrue(PieceType.ROOK.canMoveMultipleStepsInDirection(Direction.RIGHT, false));
+        
+        // 斜め方向は連続移動不可
+        assertFalse(PieceType.ROOK.canMoveMultipleStepsInDirection(Direction.UP_LEFT, false));
+        assertFalse(PieceType.ROOK.canMoveMultipleStepsInDirection(Direction.UP_RIGHT, false));
+        assertFalse(PieceType.ROOK.canMoveMultipleStepsInDirection(Direction.DOWN_LEFT, false));
+        assertFalse(PieceType.ROOK.canMoveMultipleStepsInDirection(Direction.DOWN_RIGHT, false));
+    }
+
+    /**
+     * 成飛（龍王）の方向別連続移動テスト
+     * 縦横は連続移動可、斜めは1マスのみ
+     */
+    @Test
+    void testPromotedRookCanMoveMultipleStepsInDirection() {
+        // 縦横方向は連続移動可能
+        assertTrue(PieceType.ROOK.canMoveMultipleStepsInDirection(Direction.UP, true));
+        assertTrue(PieceType.ROOK.canMoveMultipleStepsInDirection(Direction.DOWN, true));
+        assertTrue(PieceType.ROOK.canMoveMultipleStepsInDirection(Direction.LEFT, true));
+        assertTrue(PieceType.ROOK.canMoveMultipleStepsInDirection(Direction.RIGHT, true));
+        
+        // 斜め方向は連続移動不可（1マスのみ）
+        assertFalse(PieceType.ROOK.canMoveMultipleStepsInDirection(Direction.UP_LEFT, true));
+        assertFalse(PieceType.ROOK.canMoveMultipleStepsInDirection(Direction.UP_RIGHT, true));
+        assertFalse(PieceType.ROOK.canMoveMultipleStepsInDirection(Direction.DOWN_LEFT, true));
+        assertFalse(PieceType.ROOK.canMoveMultipleStepsInDirection(Direction.DOWN_RIGHT, true));
+    }
+
+    /**
+     * 歩兵は連続移動不可
+     */
+    @Test
+    void testPawnCannotMoveMultipleStepsInAnyDirection() {
+        assertFalse(PieceType.PAWN.canMoveMultipleStepsInDirection(Direction.UP, false));
+        assertFalse(PieceType.PAWN.canMoveMultipleStepsInDirection(Direction.DOWN, false));
+        assertFalse(PieceType.PAWN.canMoveMultipleStepsInDirection(Direction.LEFT, false));
+        assertFalse(PieceType.PAWN.canMoveMultipleStepsInDirection(Direction.RIGHT, false));
+    }
+
+    /**
+     * 全ての駒種が定義されていることを確認
+     */
+    @Test
+    void testAllPieceTypesAreDefined() {
+        PieceType[] types = PieceType.values();
+        
+        assertEquals(8, types.length);
+        assertEquals(PieceType.PAWN, types[0]);
+        assertEquals(PieceType.LANCE, types[1]);
+        assertEquals(PieceType.KNIGHT, types[2]);
+        assertEquals(PieceType.SILVER, types[3]);
+        assertEquals(PieceType.GOLD, types[4]);
+        assertEquals(PieceType.BISHOP, types[5]);
+        assertEquals(PieceType.ROOK, types[6]);
+        assertEquals(PieceType.KING, types[7]);
+    }
+}


### PR DESCRIPTION
# 概要  
駒の移動可能な方向を返すメソッド及び移動可能な方向をチェックするメソッドを追加

# 変更点  
- PieceTypeクラスに駒の移動可能な方向を返すメソッドを追加
- Pieceクラス、Gameクラスで駒が移動可能かチェックするメソッドを追加

# 変更理由  
- 違法手を弾くため
# テスト
- [x] コンパイルok
- [x] 単体テストok  

# その他  
その他書きたいことあったら書いてください  