### PR TITLE
#66 Fix: redis用設定をローカル用に変更，ハードコード

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,9 +3,9 @@ spring.application.name=shogi2vs2
 server.port=8080
 app.cors.allowed-origins=http://localhost:3000
 
-spring.data.redis.host=hackathon-winterkosen-redis.redis.cache.windows.net
-spring.data.redis.port=6380
-spring.data.redis.password=${redis-password}
+spring.data.redis.host=redis
+spring.data.redis.port=6379
+spring.data.redis.password=password
 
 logging.level.root=INFO
 logging.level.com.github.com.shii_park.shogi2vs2=DEBUG


### PR DESCRIPTION
# 何をやったのか  
-  redis用設定をローカル用に変更
- パスワードなどをハードコード

# なぜそうしたのか  
- 接続確認のため

# その他  
- 
- [x] ビルドOK
- [ ] テストOK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Redis接続設定を更新しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->